### PR TITLE
fix: Add scipy to environment.yml for 'edit_sys_path'

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
+  - scipy >=1.6.0
   - cmake >=3.15
   - pytest >=7.0.0
+  - jupytext >=1.16.0
   - pip
   - pip:
     - build >=1.1.0


### PR DESCRIPTION
* In the edit_sys_path example, the assumption is that numpy and scipy are installed, so include scipy in the environment.yml file.